### PR TITLE
docs(34_update_flux_for_demo.md): correct misspelling: lne

### DIFF
--- a/content/22_workshop_1/20_gitops_enable/34_update_flux_for_demo.md
+++ b/content/22_workshop_1/20_gitops_enable/34_update_flux_for_demo.md
@@ -6,7 +6,7 @@ weight: 34
 
 By default Flux will poll git every 5m but for the sake of the demo, we want to speed things up a bit.
 
-Lets edit the flux deployment and add the following argument into around lne 180 `--git-poll-interval`
+Lets edit the flux deployment and add the following argument into around line 180 `--git-poll-interval`
 
 
 Edit the following file in your prefered way:


### PR DESCRIPTION
correct misspelling: lne -> line